### PR TITLE
fix(fields): parseOutpuFields and parseAssociationOutpuFields

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,13 +26,17 @@ const sequelize = require('sequelize')
  */
 const parseOutpuFields = (info, key = null) => {
   let outputFields = graphqlFields(info)
-  if (key) outputFields = outputFields[key]
-  return Object.keys(outputFields).reduce((fields, field) => {
-    if (Object.keys(outputFields[field]).length === 0) {
-      fields.push(field)
-    }
-    return fields
-  }, [])
+  if (key) {
+    outputFields = outputFields[key]
+  }
+  return Object.keys(outputFields)
+    .filter(field => field !== '__typename')
+    .reduce((fields, field) => {
+      if (Object.keys(outputFields[field]).length === 0) {
+        fields.push(field)
+      }
+      return fields
+    }, [])
 }
 
 /**
@@ -43,13 +47,17 @@ const parseOutpuFields = (info, key = null) => {
  */
 const parseAssociationOutpuFields = (info, key = null) => {
   let outputFields = graphqlFields(info)
-  if (key) outputFields = outputFields[key]
-  return Object.keys(outputFields).reduce((fields, field) => {
-    if (Object.keys(outputFields[field]).length > 0) {
-      fields.push(field)
-    }
-    return fields
-  }, [])
+  if (key) {
+    outputFields = outputFields[key]
+  }
+  return Object.keys(outputFields)
+    .filter(field => field !== '__typename')
+    .reduce((fields, field) => {
+      if (Object.keys(outputFields[field]).length > 0) {
+        fields.push(field)
+      }
+      return fields
+    }, [])
 }
 
 /**
@@ -76,7 +84,9 @@ const getPrimaryKeyField = attributes => {
 const getFilterAttributes = (Model, info, key = null) => {
   const primaryKeyField = getPrimaryKeyField(Model.rawAttributes)
   const attributes = parseOutpuFields(info, key)
-  if (!attributes.includes(primaryKeyField)) attributes.push(primaryKeyField)
+  if (!attributes.includes(primaryKeyField)) {
+    attributes.push(primaryKeyField)
+  }
   const associationAttributes = parseAssociationOutpuFields(info, key)
   const associationAttributesMatches = Object.entries(
     Model.associations


### PR DESCRIPTION
ignoramos el field `__typename`

Algunas queries que se hacen directa sobre modelos usando ApolloClient y que utilicen el `getFilterAttributes` en el resolver agregan el `__typename` como parte de la consulta arrojando un error SQL 1054

ApolloClient agrega por defecto siempre el `__typename` a las definiciones para usarlo en el caché.


## Detalle del Error
```
{"name":"SequelizeDatabaseError","parent":{"code":"ER_BAD_FIELD_ERROR","errno":1054,"sqlState":"42S22","sqlMessage":"


Unknown column 'TermCondition.__typename' in 'field list'",

SELECT 
  `TermCondition`.`id`, 
  `TermCondition`.`texto` AS `text`, 
  `TermCondition`.`id_programa` AS `programId`, 
  `TermCondition`.`__typename`, 
  `Program`.`id` AS `Program.id`, 
  `Program`.`nombre` AS `Program.name` 
FROM `terminos_condiciones` AS `TermCondition` 
INNER JOIN 
    `programas` AS `Program` ON `TermCondition`.`id_programa` = `Program`.`id` 
  AND `Program`.`id` IN (1451, 1933) 
  AND `Program`.`deleted` = 0 
WHERE 
      `TermCondition`.`deleted` = 0 
  AND `TermCondition`.`activo` = 1 
  ORDER BY `Program`.`nombre` ASC;

```